### PR TITLE
Develop

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,7 @@
 ## Build generated
 build/
 DerivedData
-
+db/
 ## Various settings
 *.pbxuser
 !default.pbxuser

--- a/Sources/BiqCollectorExe/main.swift
+++ b/Sources/BiqCollectorExe/main.swift
@@ -64,10 +64,9 @@ let staticFilePort = 80
 let testPort = 8080
 let webroot = "./webroot"
 #else
-let staticFilePort = 8081
+let staticFilePort = 80
 let testPort = 8080
-//let webroot = "/Users/kjessup/development/TreeFrog/qBiq/qBiqCollector/webroot"
-let webroot = "./webroot"
+let webroot = "/Users/kjessup/development/TreeFrog/qBiq/qBiqCollector/webroot"
 #endif
 
 // static file server for updates

--- a/Sources/BiqCollectorExe/main.swift
+++ b/Sources/BiqCollectorExe/main.swift
@@ -64,9 +64,10 @@ let staticFilePort = 80
 let testPort = 8080
 let webroot = "./webroot"
 #else
-let staticFilePort = 80
+let staticFilePort = 8081
 let testPort = 8080
-let webroot = "/Users/kjessup/development/TreeFrog/qBiq/qBiqCollector/webroot"
+//let webroot = "/Users/kjessup/development/TreeFrog/qBiq/qBiqCollector/webroot"
+let webroot = "./webroot"
 #endif
 
 // static file server for updates

--- a/Sources/BiqCollectorLib/BiqProtoHandler.swift
+++ b/Sources/BiqCollectorLib/BiqProtoHandler.swift
@@ -14,9 +14,10 @@ public func handleBiqProtoConnection(_ connection: BiqProtoConnection) {
 		response in
 		do {
       var obs = BiqObs()
-
+      var shouldRespond = true
       if let r = try response() as? BiqReportV2 {
         CRUDLogging.log(.info, "ReportV2 read: \(r)")
+        shouldRespond = r.delegate
         obs.bixid = r.bixid
         obs.obstime = Double(r.timestamp) * 1000.0
         obs.charging = r.charging
@@ -73,7 +74,8 @@ public func handleBiqProtoConnection(_ connection: BiqProtoConnection) {
 				CRUDLogging.log(.error, "Failure while saving obs data \(error). retryReportError")
 				response = BiqResponse(version: biqProtoVersion, status: retryReportError, values: [])
 			}
-			
+
+      guard shouldRespond else { return }
 			connection.writeResponse(response) {
 				response in
 				do {

--- a/Sources/BiqCollectorLib/BiqProtoHandler.swift
+++ b/Sources/BiqCollectorLib/BiqProtoHandler.swift
@@ -19,11 +19,11 @@ public func handleBiqProtoConnection(_ connection: BiqProtoConnection) {
         CRUDLogging.log(.info, "ReportV2 read: \(r)")
         shouldRespond = r.delegate
         obs.bixid = r.bixid
-        obs.obstime = Double(r.timestamp) * 1000.0
+        obs.obstime = r.timestamp
         obs.charging = r.charging
         obs.firmware = r.fwVersion
         obs.wifiFirmware = r.wifiVersion
-        obs.battery = Double(r.battery) / 100.0
+        obs.battery = r.battery
         obs.temp = r.temperature
         obs.light = r.light
         obs.humidity = r.humidity

--- a/Sources/BiqCollectorLib/BiqProtoHandler.swift
+++ b/Sources/BiqCollectorLib/BiqProtoHandler.swift
@@ -13,36 +13,56 @@ public func handleBiqProtoConnection(_ connection: BiqProtoConnection) {
 	connection.readReport {
 		response in
 		do {
-			let report = try response()
-			CRUDLogging.log(.info, "Report read: \(report)")
-			var obs = BiqObs()
-			obs.obstime = Double.now
-			obs.bixid = report.biqId
-			obs.firmware = report.wifiVersion
-			obs.wifiFirmware = report.fwVersion
-			obs.charging = Int(report.status & reportStatusFlagCharging)
-			for reportValue in report.values {
-				switch reportValue {
-				case .temperatureOne(let temp):
-					if obs.temp == 0.0 {
-						obs.temp = Double(temp) / 10
-					}
-				case .photometric(let pho):
-					obs.light = Int(pho)
-				case .relativeHumidity(let rh):
-					obs.humidity = Int(rh)
-				case .temperatureTwo(let temp2):
-					obs.temp = Double(temp2) / 10
-				case .accelerometer(let accel):
-					let v = Int(accel)
-					obs.accelx = v
-					obs.accely = v
-					obs.accelz = v
-				case .batteryVoltage(let volts):
-					obs.battery = Double(volts) / 100
-				}
-			}
-			
+      var obs = BiqObs()
+
+      if let r = try response() as? BiqReportV2 {
+        CRUDLogging.log(.info, "ReportV2 read: \(r)")
+        obs.bixid = r.bixid
+        obs.obstime = Double(r.timestamp) * 1000.0
+        obs.charging = r.charging
+        obs.firmware = r.fwVersion
+        obs.wifiFirmware = r.wifiVersion
+        obs.battery = Double(r.battery) / 100.0
+        obs.temp = r.temperature
+        obs.light = r.light
+        obs.humidity = r.humidity
+        obs.accelx = r.accelx
+        obs.accely = r.accely
+        obs.accelz = r.accelz
+      }else if let report = try response() as? BiqReport {
+        CRUDLogging.log(.info, "Report read: \(report)")
+        obs.obstime = Double.now
+        obs.bixid = report.biqId
+        obs.firmware = report.wifiVersion
+        obs.wifiFirmware = report.fwVersion
+        obs.charging = Int(report.status & reportStatusFlagCharging)
+        for reportValue in report.values {
+          switch reportValue {
+          case .temperatureOne(let temp):
+            if obs.temp == 0.0 {
+              obs.temp = Double(temp) / 10
+            }
+          case .photometric(let pho):
+            obs.light = Int(pho)
+          case .relativeHumidity(let rh):
+            obs.humidity = Int(rh)
+          case .temperatureTwo(let temp2):
+            obs.temp = Double(temp2) / 10
+          case .accelerometer(let accel):
+            let v = Int(accel)
+            obs.accelx = v
+            obs.accely = v
+            obs.accelz = v
+          case .batteryVoltage(let volts):
+            obs.battery = Double(volts) / 100
+          }
+        }
+      } else {
+        CRUDLogging.log(.error, "Unable to read report")
+        return
+      }
+
+      print("obs:", obs)
 			let response: BiqResponse
 			do {
 				let status = noError

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,14 @@
+psql:
+  image: postgres
+  restart: always
+  ports: 
+      - "5432:5432"
+  environment:
+    - "POSTGRES_USER=postgres"
+    - "POSTGRES_PASSWORD="
+    - "PGDATA=./db"
+redis:
+  image: redis
+  restart: always
+  ports:
+    - "6379:6379"


### PR DESCRIPTION
# QBiq Protocol Version 2

This PR enables the collector to accept both V1 and V2 protocols from qBiq.

Features: harvest - one request to send multiple records, with timestamps.

A sample data of Protocol V2 looks like this:
```
K0121-1001-2SHARK,QMCU_B2.Y0.44,QESP_D1.1.48,5,1539114000,
2wK9W6MBiP+I/y0XxAQAANP////6BQAA3AK9W17+h/+G/zBjAAAAAAAAAAAMAAAA3QK9W1/
+if+K/zEXAAAAAAAAAAAAAAAA3gK9W2D+iP+J/y9YAAAAAAAAAAAeAAAA3wK9W58Bhv+H/
y4XFAAAAAAAAAASAgAA
```

## Specifications:
Leading four bytes stay the same:

C language Structure|Swift Tuple Definition
---------------------|---------------------
`struct BiqRecordHeader{` | `typealias BiqRecordHeader = (`
`unsigned short size;` | `size: UInt16,`
`unsigned char version;` | `version: UInt8,`
`unsigned char status;}` | `reserved: UInt8)`

- Payload is a `String` of `"\(devId),\(efmVersion),\(espVersion),\(count),\(clock),\(record)"`, where record is an array of base64 encoded binaries, constraint by the count number and the remote clock info, so the timestamp below should add an offset of `now - devClock`:
 
C language Structure|Swift Tuple Definition|Note
---------------------|---------------------|----------
`struct BiqRecordV2{` | `typealias BiqRecordV2 = (`|
`int32_t clk;` | `clk: Int32,`| timestamp
`int16_t bat;`| `bat: Int16,`|battery, negative for charging
`int16_t tmp;`|`tmp: Int16,`|temperature
`int16_t rht;`|`rht: Int16,`|temperature from the humidity sensor
`int8_t hum;`|`hum: Int8,`|humidity
`int8_t lum;`|`lum: Int8,`|light level/lumination
`int32_t x,y,z;}`|`x: Int32, y: Int32, z: Int32)`|accelerometer


